### PR TITLE
Create product-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+.vscode
+.idea

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "nodejs-aws-be",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kulikov98/nodejs-aws-be.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/kulikov98/nodejs-aws-be/issues"
+  },
+  "homepage": "https://github.com/kulikov98/nodejs-aws-be#readme"
+}

--- a/product-service/.gitignore
+++ b/product-service/.gitignore
@@ -1,0 +1,9 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# Webpack directories
+.webpack

--- a/product-service/database/productList.json
+++ b/product-service/database/productList.json
@@ -1,0 +1,58 @@
+[
+  {
+    "count": 4,
+    "description": "201-piece LEGO® brick set, mixed colors",
+    "id": "7567ec4b-b10c-48c5-9345-fc73c48a80aa",
+    "price": 14.99,
+    "title": "BYGGLEK"
+  },
+  {
+    "count": 6,
+    "description": "3-piece train set",
+    "id": "7567ec4b-b10c-48c5-9345-fc73c48a80a0",
+    "price": 6.99,
+    "title": "LILLABO"
+  },
+  {
+    "count": 7,
+    "description": "Watercolor box, mixed colors",
+    "id": "7567ec4b-b10c-48c5-9345-fc73c48a80a2",
+    "price": 7.99,
+    "title": "MÅLA"
+  },
+  {
+    "count": 12,
+    "description": "Soft toy, llam",
+    "id": "7567ec4b-b10c-48c5-9345-fc73c48a80a1",
+    "price": 4.99,
+    "title": "SAGOSKATT"
+  },
+  {
+    "count": 7,
+    "description": "Doll furniture, bedroom",
+    "id": "7567ec4b-b10c-48c5-9345-fc73c48a80a2",
+    "price": 17.99,
+    "title": "HUSET"
+  },
+  {
+    "count": 8,
+    "description": "Toy cash register",
+    "id": "7567ec4b-b10c-48c5-9345-fc73348a80a1",
+    "price": 17.99,
+    "title": "DUKTIG"
+  },
+  {
+    "count": 2,
+    "description": "Soft toy, dinosaur/dinosaur/brontosaurus",
+    "id": "7567ec4b-b10c-48c5-9445-fc73c48a80a2",
+    "price": 5.99,
+    "title": "JÄTTELIK"
+  },
+  {
+    "count": 3,
+    "description": "Abacus",
+    "id": "7567ec4b-b10c-45c5-9345-fc73c48a80a1",
+    "price": 9.99,
+    "title": "MULA"
+  }
+]

--- a/product-service/handler.ts
+++ b/product-service/handler.ts
@@ -1,0 +1,4 @@
+import { getProductsList } from "./handlers/getProductsList";
+import { getProductsById } from "./handlers/getProductsById";
+
+export { getProductsList, getProductsById };

--- a/product-service/handlers/getProductsById.ts
+++ b/product-service/handlers/getProductsById.ts
@@ -1,0 +1,16 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import 'source-map-support/register';
+import productsList from '../database/productList.json';
+
+
+export const getProductsById: APIGatewayProxyHandler = async (event, _context) => {
+    const product = productsList.find(el => el.id === event.pathParameters.id);
+
+    return {
+        headers: {
+            'Access-Control-Allow-Origin': '*'
+        },
+        statusCode: 200,
+        body: JSON.stringify(product, null, 2),
+    };
+}

--- a/product-service/handlers/getProductsList.ts
+++ b/product-service/handlers/getProductsList.ts
@@ -1,0 +1,14 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import 'source-map-support/register';
+import productsList from '../database/productList.json';
+
+
+export const getProductsList: APIGatewayProxyHandler = async () => {
+    return {
+        headers: {
+            'Access-Control-Allow-Origin': '*'
+        },
+        statusCode: 200,
+        body: JSON.stringify(productsList, null, 2),
+    };
+}

--- a/product-service/package.json
+++ b/product-service/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "product-service",
+  "version": "1.0.0",
+  "description": "Serverless webpack example using Typescript",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "source-map-support": "^0.5.10"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.17",
+    "@types/node": "^10.12.18",
+    "@types/serverless": "^1.72.5",
+    "fork-ts-checker-webpack-plugin": "^3.0.1",
+    "serverless-webpack": "^5.2.0",
+    "ts-loader": "^5.3.3",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.2.4",
+    "webpack": "^4.29.0",
+    "webpack-node-externals": "^1.7.2"
+  },
+  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/product-service/serverless.ts
+++ b/product-service/serverless.ts
@@ -1,0 +1,61 @@
+import { Serverless } from 'serverless/aws';
+
+const serverlessConfiguration: Serverless = {
+  service: {
+    name: 'product-service',
+  },
+  frameworkVersion: '2',
+  custom: {
+    webpack: {
+      webpackConfig: './webpack.config.js',
+      includeModules: true
+    }
+  },
+  // Add the serverless-webpack plugin
+  plugins: ['serverless-webpack'],
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs12.x',
+    apiGateway: {
+      minimumCompressionSize: 1024,
+    },
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+    },
+  },
+  functions: {
+    getProductsList: {
+      handler: 'handler.getProductsList',
+      events: [
+        {
+          http: {
+            method: 'get',
+            path: 'products',
+            cors: true,
+          }
+        }
+      ]
+    },
+    getProductsById: {
+      handler: 'handler.getProductsById',
+      events: [
+        {
+          http: {
+            method: 'get',
+            path: 'products/{id}',
+            cors: true,
+            request: {
+              parameters: {
+                paths: {
+                  id: true
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+  }
+}
+
+module.exports = serverlessConfiguration;

--- a/product-service/tsconfig.json
+++ b/product-service/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "removeComments": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2017",
+    "outDir": "lib"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ]
+}

--- a/product-service/webpack.config.js
+++ b/product-service/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'cheap-module-eval-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [
+    // new ForkTsCheckerWebpackPlugin({
+    //   eslint: true,
+    //   eslintOptions: {
+    //     cache: true
+    //   }
+    // })
+  ],
+};


### PR DESCRIPTION
**The main part is done.**

Additional scope: 

- async/await
- modules
- webpack
- handlers are not in a single file

**Link to product-service API** - https://d97a9e7c5b.execute-api.us-east-1.amazonaws.com/dev/products/
**LInk to FE MR** - https://github.com/kulikov98/nodejs-aws-fe/pull/2
**Link to deployed FE** - https://d1nl6kxw7my892.cloudfront.net/
The product schema has kept the same.

**FYI**: `aws-nodejs-typescript` template uses `serverless.ts` instead of yaml